### PR TITLE
Added support for exact matching of Arabic and Chinese

### DIFF
--- a/src/hdx/location/country.py
+++ b/src/hdx/location/country.py
@@ -745,6 +745,14 @@ class Country:
                 iso3 = countriesdata["countrynames2iso3"].get(candidate)
                 if iso3 is not None:
                     return iso3
+        elif re.search(r"[\u4e00-\u9fff]+", countryupper):
+            for country in countriesdata["countries"]:
+                if countriesdata["countries"][country]["#country+alt+i_zh+name+v_unterm"] == countryupper:
+                    return country
+        elif re.search(r"[\u0621-\u064A]+", countryupper):
+            for country in countriesdata["countries"]:
+                if countriesdata["countries"][country]["#country+alt+i_ar+name+v_unterm"] == countryupper:
+                    return country
 
         if exception is not None:
             raise exception

--- a/src/hdx/location/country.py
+++ b/src/hdx/location/country.py
@@ -747,11 +747,21 @@ class Country:
                     return iso3
         elif re.search(r"[\u4e00-\u9fff]+", countryupper):
             for country in countriesdata["countries"]:
-                if countriesdata["countries"][country]["#country+alt+i_zh+name+v_unterm"] == countryupper:
+                if (
+                    countriesdata["countries"][country][
+                        "#country+alt+i_zh+name+v_unterm"
+                    ]
+                    == countryupper
+                ):
                     return country
-        elif re.search(r"[\u0621-\u064A]+", countryupper):
+        elif re.search(r"[\u0600-\u06FF]+", countryupper):
             for country in countriesdata["countries"]:
-                if countriesdata["countries"][country]["#country+alt+i_ar+name+v_unterm"] == countryupper:
+                if (
+                    countriesdata["countries"][country][
+                        "#country+alt+i_ar+name+v_unterm"
+                    ]
+                    == countryupper
+                ):
                     return country
 
         if exception is not None:

--- a/tests/hdx/location/test_country.py
+++ b/tests/hdx/location/test_country.py
@@ -455,8 +455,7 @@ class TestCountry:
         assert Country.get_iso3_country_code("Russian Fed.") == "RUS"
         assert Country.get_iso3_country_code("中国") == "CHN"
         assert (
-            Country.get_iso3_country_code("المملكة العربية السعودية")
-            == "SAU"
+            Country.get_iso3_country_code("المملكة العربية السعودية") == "SAU"
         )
         assert (
             Country.get_iso3_country_code("Micronesia (Federated States of)")

--- a/tests/hdx/location/test_country.py
+++ b/tests/hdx/location/test_country.py
@@ -453,6 +453,11 @@ class TestCountry:
         assert Country.get_iso3_country_code("jpn") == "JPN"
         assert Country.get_iso3_country_code("Dem. Rep. of the Congo") == "COD"
         assert Country.get_iso3_country_code("Russian Fed.") == "RUS"
+        assert Country.get_iso3_country_code("中国") == "CHN"
+        assert (
+            Country.get_iso3_country_code("المملكة العربية السعودية")
+            == "SAU"
+        )
         assert (
             Country.get_iso3_country_code("Micronesia (Federated States of)")
             == "FSM"


### PR DESCRIPTION
Fixes an issue where Arabic and Chinese text were not being matched (e.g. 中国 for China). Solves issue #9. 

I resolved the issue by adding two conditionals to `get_iso3_country_code()` that detect each character set respectively and search through the dictionary to retrieve the ISO3 code, or else return None like usual. 

When Arabic or Chinese text was previously passed into the function, the `if countryupper.isupper()` conditional would return False, and the function would return None. 

I think this is the only method that needed this fix, as it's the only method in `country.py` that takes a generic country string as opposed to ISO3/ISO2/M49 and then converts it, but if I missed another method then this fix should be able to be adapted to it easily.