### PR TITLE
HDXDSYS-1126  HDX Python Country - make get_libhxl_dataset method static

### DIFF
--- a/documentation/main.md
+++ b/documentation/main.md
@@ -130,6 +130,10 @@ object has been set up with parents). Keys take the form "STRING_TO_REPLACE",
 *admin_fuzzy_dont* is a list of names for which fuzzy matching should not be
 tried
 
+A Retrieve object can be passed in the *retriever* parameter that enables
+saving data downloaded to a file or loading previously saved data depending
+on how the Retrieve object is configured.
+
 Once an AdminLevel object is constructed, one of three setup methods must be
 called: *setup_from_admin_info*, *setup_from_libhxl_dataset* or
 *setup_from_url*.

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ frictionless==5.18.0
     # via hdx-python-utilities
 hdx-python-utilities==3.7.4
     # via hdx-python-country (pyproject.toml)
-humanize==4.10.0
+humanize==4.11.0
     # via frictionless
 identify==2.6.1
     # via pre-commit
@@ -82,7 +82,7 @@ ply==3.11
     # via
     #   jsonpath-ng
     #   libhxl
-pre-commit==3.8.0
+pre-commit==4.0.0
     # via hdx-python-country (pyproject.toml)
 pydantic==2.9.2
     # via frictionless
@@ -127,7 +127,7 @@ requests-file==2.1.0
     # via hdx-python-utilities
 rfc3986==2.0.0
     # via frictionless
-rich==13.9.1
+rich==13.9.2
     # via typer
 rpds-py==0.20.0
     # via
@@ -139,7 +139,7 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 shellingham==1.5.4
     # via typer
-simpleeval==0.9.13
+simpleeval==1.0.0
     # via frictionless
 six==1.16.0
     # via

--- a/src/hdx/location/adminlevel.py
+++ b/src/hdx/location/adminlevel.py
@@ -115,20 +115,24 @@ class AdminLevel:
             admin_url = cls._admin_url_default
         cls._admin_url = admin_url
 
-    def get_libhxl_dataset(self, url: str = _admin_url) -> hxl.Dataset:
+    @staticmethod
+    def get_libhxl_dataset(
+        url: str = _admin_url, retriever: Optional[Retrieve] = None
+    ) -> hxl.Dataset:
         """
         Get libhxl Dataset object given a URL which defaults to global p-codes
         dataset on HDX.
 
         Args:
-            admin_url (str): URL from which to load data.
+            url (str): URL from which to load data. Defaults to internal admin url.
+            retriever (Optional[Retrieve]): Retriever object to use for loading file. Defaults to None.
 
         Returns:
-            None
+            hxl.Dataset: HXL Dataset object
         """
-        if self.retriever:
+        if retriever:
             try:
-                url_to_use = self.retriever.download_file(url)
+                url_to_use = retriever.download_file(url)
             except DownloadError:
                 logger.exception(
                     f"Setup of libhxl Dataset object with {url} failed!"
@@ -271,7 +275,7 @@ class AdminLevel:
         Returns:
             None
         """
-        admin_info = self.get_libhxl_dataset(admin_url)
+        admin_info = self.get_libhxl_dataset(admin_url, self.retriever)
         self.setup_from_libhxl_dataset(admin_info, countryiso3s)
 
     def load_pcode_formats(self, formats_url: str = _formats_url) -> None:
@@ -284,7 +288,7 @@ class AdminLevel:
         Returns:
             None
         """
-        formats_info = self.get_libhxl_dataset(formats_url)
+        formats_info = self.get_libhxl_dataset(formats_url, self.retriever)
         for row in formats_info:
             pcode_format = [int(row.get("#country+len"))]
             for admin_no in range(1, 4):


### PR DESCRIPTION
Fix for HAPI so that Retrieve object is passed and hence get_libhxl_dataset method can be static