### PR TITLE
Rework country simplification

### DIFF
--- a/src/hdx/location/country.py
+++ b/src/hdx/location/country.py
@@ -3,7 +3,6 @@
 import logging
 import os.path
 import re
-from itertools import tee
 from typing import Dict, List, Optional, Tuple, Union
 
 import hxl

--- a/src/hdx/location/country.py
+++ b/src/hdx/location/country.py
@@ -724,7 +724,7 @@ class Country:
         if not country:
             return "", []
 
-        countryupper = country.upper()
+        countryupper = country.upper().strip()
         words = get_words_in_sentence(countryupper)
         index = countryupper.find(",")
         if index != -1:

--- a/src/hdx/location/country.py
+++ b/src/hdx/location/country.py
@@ -721,6 +721,9 @@ class Country:
         Returns:
             Tuple[str, List[str]]: Uppercase simplified country name and list of removed words
         """
+        if not country:
+            return "", []
+
         countryupper = country.upper()
         words = get_words_in_sentence(countryupper)
         index = countryupper.find(",")
@@ -746,7 +749,7 @@ class Country:
             cls.abbreviations.keys(),
             cls.abbreviations.values(),
             cls.multiple_abbreviations.keys(),
-        ] + cls.multiple_abbreviations.values():
+        ] + list(cls.multiple_abbreviations.values()):
             for term in terms:
                 if " " in term:
                     multiword_terms.add(term)
@@ -785,9 +788,10 @@ class Country:
 
         if candidate_words:
             simplified_term = next(
-                word for word in candidate_words if word not in singleword_terms
+                (word for word in candidate_words if word not in singleword_terms), ""
             )
-            words.remove(simplified_term)
+            if simplified_term:
+                words.remove(simplified_term)
         else:
             simplified_term = ""
 

--- a/src/hdx/location/country.py
+++ b/src/hdx/location/country.py
@@ -781,14 +781,12 @@ class Country:
             if start != 0:
                 new_candidate_words.extend(candidate_words[start:])
                 candidate_words = new_candidate_words
-            # ELse we didn't find the words consecutively and don't need to rebuild
+            # Else we didn't find the words consecutively and don't need to rebuild
 
-        candidate_words = [
-            word for word in candidate_words if word not in singleword_terms
-        ]
-
-        if len(candidate_words) >= 1:
-            simplified_term = candidate_words[0]
+        if candidate_words:
+            simplified_term = next(
+                word for word in candidate_words if word not in singleword_terms
+            )
             words.remove(simplified_term)
         else:
             simplified_term = ""

--- a/src/hdx/location/country.py
+++ b/src/hdx/location/country.py
@@ -779,7 +779,7 @@ class Country:
                     # If the current term is the first word in a multi-part term
                     (term_parts := multiword_terms.get(word))
                     # And there are enough words left in the sentence
-                    and i + len(term_parts) < num_candidate_words
+                    and i + len(term_parts) <= num_candidate_words
                     # And all of the words in the multi-word phrase are in sequence
                     # in the candidate term starting at the current position
                     and all(

--- a/tests/hdx/location/test_country.py
+++ b/tests/hdx/location/test_country.py
@@ -707,6 +707,10 @@ class TestCountry:
             "KOREA",
             ["THE", "REPUBLIC", "OF"],
         )
+        assert Country.simplify_countryname("   (the Republic of Korea)   ") == (
+            "KOREA",
+            ["THE", "REPUBLIC", "OF"],
+        )
         assert Country.simplify_countryname("(Sometimes) Korea") == (
             "KOREA",
             ["SOMETIMES"],

--- a/tests/hdx/location/test_country.py
+++ b/tests/hdx/location/test_country.py
@@ -653,7 +653,34 @@ class TestCountry:
             "MICRONESIA",
             ["FEDERATED", "STATES", "OF"],
         )
+        assert Country.simplify_countryname("Federated States of Micronesia") == (
+            "MICRONESIA",
+            ["FEDERATED", "STATES", "OF"],
+        )
+        assert Country.simplify_countryname("(Federated States of) Micronesia") == (
+            "MICRONESIA",
+            ["FEDERATED", "STATES", "OF"],
+        )
+        assert Country.simplify_countryname("French Part of Saint Martin") == (
+            "MARTIN",
+            ["FRENCH", "PART", "OF", "SAINT"],
+        )
+        assert Country.simplify_countryname("French Part of Saint-Martin") == (
+            "MARTIN",
+            ["FRENCH", "PART", "OF", "SAINT"],
+        )
+        # "French Part" is a simplification and so can't be the simplified term
+        assert Country.simplify_countryname("French Part") == ("", ["FRENCH", "PART"])
+        # But the words must be consecutive
+        assert Country.simplify_countryname("French and Part") == (
+            "FRENCH",
+            ["AND", "PART"],
+        )
         assert Country.simplify_countryname("Dem. Rep. of the Congo") == (
+            "CONGO",
+            ["DEM", "REP", "OF", "THE"],
+        )
+        assert Country.simplify_countryname("Dem Rep of the Congo") == (
             "CONGO",
             ["DEM", "REP", "OF", "THE"],
         )
@@ -671,10 +698,45 @@ class TestCountry:
             "KOREA",
             ["THE", "REPUBLIC", "OF"],
         )
+        assert Country.simplify_countryname("(the Republic of Korea)") == (
+            "KOREA",
+            ["THE", "REPUBLIC", "OF"],
+        )
+        assert Country.simplify_countryname("(Sometimes) Korea") == (
+            "KOREA",
+            ["SOMETIMES"],
+        )
         assert Country.simplify_countryname(
             "The former Yugoslav Republic of Macedonia"
         ) == ("MACEDONIA", ["THE", "FORMER", "YUGOSLAV", "REPUBLIC", "OF"])
         assert Country.simplify_countryname("d'Ivoire Côte") == ("D'IVOIRE", ["CÔTE"])
+        assert Country.simplify_countryname("Guinea-Bissau") == ("GUINEA", ["BISSAU"])
+        assert Country.simplify_countryname("People's Republic of Bangladesh") == (
+            "BANGLADESH",
+            ["PEOPLE'S", "REPUBLIC", "OF"],
+        )
+        assert Country.simplify_countryname("Peoples Republic of Bangladesh") == (
+            "BANGLADESH",
+            ["PEOPLES", "REPUBLIC", "OF"],
+        )
+        # Known limitation with "smart quote" handling
+        assert Country.simplify_countryname("People’s Republic of Bangladesh") == (
+            "PEOPLE’S",
+            ["REPUBLIC", "OF", "BANGLADESH"],
+        )
+        # Simplifying assumes that it isn't getting an address and simplifies to the first
+        # part around commas, even if it isn't a country
+        assert Country.simplify_countryname("Paris, France") == (
+            "PARIS",
+            ["FRANCE"],
+        )
+        # Some people supply strings that aren't countries
+        # (often indirectly via `get_iso3_country_code_fuzzy()`)
+        # Ensure the function doesn't error, even if the value is meaningless.
+        assert Country.simplify_countryname("3.1 Global scores and ranking") == (
+            "3",
+            ["1", "GLOBAL", "SCORES", "AND", "RANKING"],
+        )
 
     def test_get_iso3_country_code(self):
         assert Country.get_iso3_country_code("jpn") == "JPN"

--- a/tests/hdx/location/test_country.py
+++ b/tests/hdx/location/test_country.py
@@ -644,7 +644,8 @@ class TestCountry:
         ]
 
     def test_simplify_countryname(self):
-        assert Country.simplify_countryname("jpn") == ("JPN", list())
+        assert Country.simplify_countryname("") == ("", [])
+        assert Country.simplify_countryname("jpn") == ("JPN", [])
         assert Country.simplify_countryname("United Rep. of Tanzania") == (
             "TANZANIA",
             ["UNITED", "REP", "OF"],
@@ -660,6 +661,10 @@ class TestCountry:
         assert Country.simplify_countryname("(Federated States of) Micronesia") == (
             "MICRONESIA",
             ["FEDERATED", "STATES", "OF"],
+        )
+        assert Country.simplify_countryname("Federated States") == (
+            "",
+            ["FEDERATED", "STATES"],
         )
         assert Country.simplify_countryname("French Part of Saint Martin") == (
             "MARTIN",


### PR DESCRIPTION
Rework the country simplification code to try and avoid corner cases. Rather than breaking the string into words, doing lots of mutations, breaking _that_ string into words and then trying to remove a word from the initial list, we break the string into words, do some simple truncation, break that into words (which should now be guaranteed to be a subset of the initial words) and then work out which words we can drop.

Addresses #77